### PR TITLE
Add extra check to only show controls in main title

### DIFF
--- a/src/scrummer.js
+++ b/src/scrummer.js
@@ -208,8 +208,10 @@ var buildPicker = function (values, callback) {
 var setupWindowListener = function (callback) {
   var windowChangeObserver = new MutationObserver(function (mutations) {
     mutations.forEach(function (mutation) {
+      var previousSibling = mutation.target.previousSibling;
       if (mutation.target.classList.contains('edit-controls') &&
-          mutation.target.previousSibling.classList.contains('single-line')) {
+          previousSibling.classList.contains('single-line') &&
+          !previousSibling.classList.contains('full')) {
         callback();
       }
     });


### PR DESCRIPTION
Before this commit the extension also showed the points buttons
in the edit of a checklist title. 

![screen shot 2015-10-07 at 11 56 07](https://cloud.githubusercontent.com/assets/213502/10334626/baa4610a-6ceb-11e5-930b-7cc45ef62826.png)

Fixes https://github.com/rickpastoor/scrummer/issues/16
